### PR TITLE
fix: Pre-Commit hook task not being registered.

### DIFF
--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -24,6 +24,7 @@ class KotlinterPlugin : Plugin<Project> {
 
         if (this == rootProject) {
             registerPrePushHookTask()
+            registerPreCommitHookTask()
         }
 
         // for known kotlin plugins, register tasks by convention.


### PR DESCRIPTION
There is a function to define the plugins pre-commit hook task, but it is never registered.
Results in `Task with path 'installKotlinterPreCommitHook' not found in root project` when using `dependsOn("installKotlinterPreCommitHook")` in a project.